### PR TITLE
Only provide function name to CallContext in debug

### DIFF
--- a/itest/rust/src/benchmarks/mod.rs
+++ b/itest/rust/src/benchmarks/mod.rs
@@ -13,6 +13,7 @@ use godot::builtin::inner::InnerRect2i;
 use godot::builtin::{GString, PackedInt32Array, Rect2i, StringName, Vector2i};
 use godot::classes::{Node3D, Os, RefCounted};
 use godot::obj::{Gd, InstanceId, NewAlloc, NewGd, Singleton};
+use godot::prelude::{varray, Callable, RustCallable, Variant};
 use godot::register::GodotClass;
 
 use crate::framework::bench;
@@ -113,9 +114,36 @@ fn packed_array_from_iter_unknown_size() -> PackedInt32Array {
     }))
 }
 
+#[bench(repeat = 25)]
+fn call_callv_rust_fn() -> Variant {
+    let callable = Callable::from_fn("RustFunction", |_| ());
+    callable.callv(&varray![])
+}
+
+#[bench(repeat = 25)]
+fn call_callv_custom() -> Variant {
+    let callable = Callable::from_custom(MyRustCallable {});
+    callable.callv(&varray![])
+}
+
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Helpers for benchmarks above
 
 #[derive(GodotClass)]
 #[class(init)]
 struct MyBenchType {}
+
+#[derive(PartialEq, Hash)]
+struct MyRustCallable {}
+
+impl RustCallable for MyRustCallable {
+    fn invoke(&mut self, _args: &[&Variant]) -> Variant {
+        Variant::nil()
+    }
+}
+
+impl std::fmt::Display for MyRustCallable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "MyRustCallable")
+    }
+}


### PR DESCRIPTION
Only provides function name to `CallContext` on debug builds for a fair bit of an optimization on release builds.

Result of the benchmarks:
```
with opt
   -- call_callv_rust_fn         ...      0.856μs      0.880μs
   -- call_callv_custom          ...      0.750μs      0.767μs
without
   -- call_callv_rust_fn         ...      1.126μs      1.164μs
   -- call_callv_custom          ...      0.791μs      0.808μs
```

Less of a gain on the custom call side, but I think that's mostly just because `GString.to_string` is that much more expensive, or your mileage may vary depending on what the implementation of `std::fmt::Display` is for a `RustCallable` in the wild.

Bonus: I added the option to provide a release argument to `check.sh`, but lemme know if I should put that up in a separate PR. Just made testing this so much easier (although I feel like I should clarify that the benchmarks above were not debug vs release, to be clear).

What an adventure this has been 😅